### PR TITLE
dotnet-format-03-Sep-2021: fix code guidelines violations

### DIFF
--- a/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
@@ -22,18 +22,7 @@ namespace DotNet.Sdk.Extensions.Options
         public static OptionsBuilder<T> AddOptionsValue<T>(this IServiceCollection services, IConfiguration configuration)
             where T : class, new()
         {
-
-/* Unmerged change from project 'DotNet.Sdk.Extensions(netcoreapp3.1)'
-Before:
             if (services is null)            {                throw new ArgumentNullException(nameof(services));
-After:
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-*/
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
             }
 
             return services

--- a/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
@@ -22,7 +22,18 @@ namespace DotNet.Sdk.Extensions.Options
         public static OptionsBuilder<T> AddOptionsValue<T>(this IServiceCollection services, IConfiguration configuration)
             where T : class, new()
         {
+
+/* Unmerged change from project 'DotNet.Sdk.Extensions(netcoreapp3.1)'
+Before:
             if (services is null)            {                throw new ArgumentNullException(nameof(services));
+After:
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+*/
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
             }
 
             return services

--- a/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
@@ -25,6 +25,7 @@ namespace DotNet.Sdk.Extensions.Options
             if (services is null)            {                throw new ArgumentNullException(nameof(services));
             }
 
+
             return services
                 .AddOptions<T>()
                 .Bind(configuration)


### PR DESCRIPTION
**dotnet format** [workflow run](https://github.com/edumserrano/dot-net-sdk-extensions/actions/runs/1199617932) detected code guidelines violations and
automatically created this PR.

:warning: Please review the suggested changes before merging.

**Note**: sometimes dotnet format adds unecessary commets when formatting files. This seems to happen when 
supporting multiple target frameworks. If this happens you should remove the comments. 