### PR TITLE
dotnet-format-05-Sep-2021: fix code guidelines violations

### DIFF
--- a/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
+++ b/src/DotNet.Sdk.Extensions/Options/OptionsBuilderExtensions.cs
@@ -26,6 +26,7 @@ namespace DotNet.Sdk.Extensions.Options
             {
                 throw new ArgumentNullException(nameof(services));
             }
+
             return services
                 .AddOptions<T>()
                 .Bind(configuration)


### PR DESCRIPTION
**dotnet format** [workflow run](https://github.com/edumserrano/dot-net-sdk-extensions/actions/runs/1203368005) detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

## Note        
Sometimes the fix provided by the analyzers produces unecessary comments when formatting files. 

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the `Unmerged change from project ...` comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:
```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```