### PR TITLE
Reduce tests total runtime

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -435,6 +435,8 @@ dotnet_diagnostic.RCS1126.severity = suggestion     # RCS1126: Add braces to if-
 dotnet_diagnostic.RCS1196.severity = suggestion     # RCS1196: Call extension method as instance method
 dotnet_diagnostic.RCS1208.severity = none           # RCS1208: Reduce 'if' nesting
 dotnet_diagnostic.RCS1248.severity = suggestion     # RCS1248: Use pattern matching to check for null (or vice versa)
+# Usage
+dotnet_diagnostic.RCS1221.severity = none           # RCS1221: Use pattern matching instead of combination of 'as' operator and null check
 
 ##########################################
 # Rules for Roslynator.Formatting.Analyzers

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/HttpPoliciesReflectionExtensions.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Auxiliary/HttpPoliciesReflectionExtensions.cs
@@ -1,23 +1,31 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.Http;
 using Polly;
+using Polly.CircuitBreaker;
+using Polly.Wrap;
 
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Auxiliary
 {
     public static class HttpPoliciesReflectionExtensions
     {
-        public static IEnumerable<T> GetPolicies<T>(this IList<DelegatingHandler> delegatingHandlers)
+        public static IEnumerable<T> GetPolicies<T>(this HttpMessageHandlerBuilder httpMessageHandlerBuilder)
         {
-            return delegatingHandlers
+            return httpMessageHandlerBuilder
                 .GetPolicies()
                 .OfType<T>();
         }
 
-        public static IEnumerable<IsPolicy> GetPolicies(this IList<DelegatingHandler> delegatingHandlers)
+        public static IEnumerable<IsPolicy> GetPolicies(this HttpMessageHandlerBuilder httpMessageHandlerBuilder)
         {
-            return delegatingHandlers
+            if (httpMessageHandlerBuilder is null)
+            {
+                throw new ArgumentNullException(nameof(httpMessageHandlerBuilder));
+            }
+
+            return httpMessageHandlerBuilder.AdditionalHandlers
                 .OfType<PolicyHttpMessageHandler>()
                 .Select(x => x.GetPolicy<IsPolicy>())
                 .Where(x => x is not null)
@@ -27,6 +35,36 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Auxiliary
         public static T? GetPolicy<T>(this PolicyHttpMessageHandler policyHttpMessageHandler)
         {
             return policyHttpMessageHandler.GetInstanceField<T>("_policy");
+        }
+
+        public static AsyncCircuitBreakerPolicy<HttpResponseMessage>? GetAsyncCircuitBreakerPolicy(this HttpClient httpClient)
+        {
+            var handler = httpClient.GetInstanceField<DelegatingHandler>(typeof(HttpMessageInvoker), "_handler");
+            while (handler is not null)
+            {
+                if (handler is PolicyHttpMessageHandler)
+                {
+                    var policy = handler.GetInstanceField<IAsyncPolicy<HttpResponseMessage>>("_policy");
+                    if (policy is AsyncPolicyWrap<HttpResponseMessage> wrapPolicy)
+                    {
+                        var circuitBreakerPolicy = wrapPolicy.Inner as AsyncCircuitBreakerPolicy<HttpResponseMessage>;
+                        if (circuitBreakerPolicy is not null)
+                        {
+                            return circuitBreakerPolicy;
+                        }
+                    }
+                }
+
+                handler = handler.InnerHandler as DelegatingHandler;
+            }
+
+            return null;
+        }
+
+        public static void ResetCircuitBreakerPolicy(this HttpClient httpClient)
+        {
+            var circuitBreakerPolicy = httpClient.GetAsyncCircuitBreakerPolicy();
+            circuitBreakerPolicy?.Reset();
         }
     }
 }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
@@ -44,7 +44,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             _resetType = resetType;
             return this;
         }
-        
+
         public async Task HttpClientShouldContainCircuitBreakerPolicyAsync()
         {
             await CircuitBreakerPolicyHandlesTransientStatusCodes();
@@ -61,18 +61,18 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             eventHandlerCalls
                 .OnBreakAsyncCalls
                 .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)
-                            && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
-                            && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
-                            && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
-                            && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
+                    && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
+                    && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
+                    && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
+                    && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
                 .ShouldBe(count);
             eventHandlerCalls
                 .OnResetAsyncCalls
                 .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)
-                            && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
-                            && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
-                            && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
-                            && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
+                    && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
+                    && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
+                    && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
+                    && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
                 .ShouldBe(count);
 
             // when the circuit breaker is used the break and reset events are always triggered. However, when
@@ -84,10 +84,10 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
                 eventHandlerCalls
                     .OnHalfOpenAsyncCalls
                     .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)
-                                && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
-                                && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
-                                && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
-                                && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
+                        && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
+                        && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
+                        && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
+                        && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
                     .ShouldBe(count);
             }
         }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
@@ -80,7 +80,6 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             // So we only check for then when the reset type is CircuitBreakerPolicyExecutorResetTypes.Normal
             if (_resetType == CircuitBreakerPolicyExecutorResetTypes.Normal)
             {
-                EventHandlerShouldReceiveExpectedEvents(count, httpClientName, eventHandlerCalls);
                 eventHandlerCalls
                     .OnHalfOpenAsyncCalls
                     .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyAsserter.cs
@@ -26,6 +26,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
         private readonly HttpClient _httpClient;
         private readonly CircuitBreakerOptions _options;
         private readonly TestHttpMessageHandler _testHttpMessageHandler;
+        private CircuitBreakerPolicyExecutorResetTypes _resetType;
 
         public CircuitBreakerPolicyAsserter(
             HttpClient httpClient,
@@ -35,8 +36,15 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             _httpClient = httpClient;
             _options = options;
             _testHttpMessageHandler = testHttpMessageHandler;
+            _resetType = CircuitBreakerPolicyExecutorResetTypes.Quick;
         }
 
+        public CircuitBreakerPolicyAsserter WithReset(CircuitBreakerPolicyExecutorResetTypes resetType)
+        {
+            _resetType = resetType;
+            return this;
+        }
+        
         public async Task HttpClientShouldContainCircuitBreakerPolicyAsync()
         {
             await CircuitBreakerPolicyHandlesTransientStatusCodes();
@@ -53,34 +61,44 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             eventHandlerCalls
                 .OnBreakAsyncCalls
                 .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)
-                    && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
-                    && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
-                    && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
-                    && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
+                            && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
+                            && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
+                            && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
+                            && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
                 .ShouldBe(count);
             eventHandlerCalls
                 .OnResetAsyncCalls
                 .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)
-                    && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
-                    && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
-                    && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
-                    && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
+                            && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
+                            && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
+                            && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
+                            && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
                 .ShouldBe(count);
-            eventHandlerCalls
-                .OnHalfOpenAsyncCalls
-                .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)
-                    && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
-                    && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
-                    && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
-                    && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
-                .ShouldBe(count);
+
+            // when the circuit breaker is used the break and reset events are always triggered. However, when
+            // the circuit breaker reset type is set to quick, the on half open events are never triggered.
+            // So we only check for then when the reset type is CircuitBreakerPolicyExecutorResetTypes.Normal
+            if (_resetType == CircuitBreakerPolicyExecutorResetTypes.Normal)
+            {
+                EventHandlerShouldReceiveExpectedEvents(count, httpClientName, eventHandlerCalls);
+                eventHandlerCalls
+                    .OnHalfOpenAsyncCalls
+                    .Count(x => x.HttpClientName.Equals(httpClientName, StringComparison.Ordinal)
+                                && x.CircuitBreakerOptions.DurationOfBreakInSecs.Equals(_options.DurationOfBreakInSecs)
+                                && x.CircuitBreakerOptions.FailureThreshold.Equals(_options.FailureThreshold)
+                                && x.CircuitBreakerOptions.MinimumThroughput.Equals(_options.MinimumThroughput)
+                                && x.CircuitBreakerOptions.SamplingDurationInSecs.Equals(_options.SamplingDurationInSecs))
+                    .ShouldBe(count);
+            }
         }
 
         private async Task CircuitBreakerPolicyHandlesTransientStatusCodes()
         {
             foreach (var transientHttpStatusCode in HttpStatusCodesExtensions.GetTransientHttpStatusCodes())
             {
-                await using var circuitBreaker = _httpClient.CircuitBreakerExecutor(_options, _testHttpMessageHandler);
+                await using var circuitBreaker = _httpClient
+                    .CircuitBreakerExecutor(_options, _testHttpMessageHandler)
+                    .WithReset(_resetType);
                 await circuitBreaker.TriggerFromTransientHttpStatusCodeAsync(transientHttpStatusCode);
                 await circuitBreaker.ShouldBeOpenAsync($"/circuit-breaker/transient-http-status-code/{transientHttpStatusCode}");
             }
@@ -96,7 +114,9 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
         private async Task CircuitBreakerPolicyHandlesException<TException>(TException exception)
             where TException : Exception
         {
-            await using var circuitBreaker = _httpClient.CircuitBreakerExecutor(_options, _testHttpMessageHandler);
+            await using var circuitBreaker = _httpClient
+                .CircuitBreakerExecutor(_options, _testHttpMessageHandler)
+                .WithReset(_resetType);
             await circuitBreaker.TriggerFromExceptionAsync<TException>(exception);
             await circuitBreaker.ShouldBeOpenAsync($"/circuit-breaker/exception/{exception.GetType().Name}");
         }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyExecutor.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyExecutor.cs
@@ -44,7 +44,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             _resetType = resetType;
             return this;
         }
-        
+
         public Task TriggerFromExceptionAsync<TException>(Exception exception)
             where TException : Exception
         {
@@ -66,7 +66,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
                 responseHttpStatusCode: httpStatusCode);
             return TriggerCircuitBreakerFromTransientStatusCodeAsync(handledRequestPath, httpStatusCode);
         }
-        
+
         private async Task WaitResetAsync()
         {
             // wait for the duration of break so that the circuit goes into half open state

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyExecutor.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Auxiliary/CircuitBreakerPolicyExecutor.cs
@@ -11,13 +11,20 @@ using DotNet.Sdk.Extensions.Tests.Polly.Http.Auxiliary;
 
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
 {
+    public enum CircuitBreakerPolicyExecutorResetTypes
+    {
+        Quick,
+        Normal,
+    }
+
     public sealed class CircuitBreakerPolicyExecutor : IAsyncDisposable
     {
         private readonly HttpClient _httpClient;
+        private readonly string _resetRequestPath;
         private readonly CircuitBreakerOptions _circuitBreakerOptions;
         private readonly TestHttpMessageHandler _testHttpMessageHandler;
-        private readonly string _resetRequestPath;
         private readonly List<HttpStatusCode> _transientHttpStatusCodes;
+        private CircuitBreakerPolicyExecutorResetTypes _resetType;
 
         public CircuitBreakerPolicyExecutor(
             HttpClient httpClient,
@@ -29,8 +36,15 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             _testHttpMessageHandler = testHttpMessageHandler;
             _resetRequestPath = HandleResetRequest();
             _transientHttpStatusCodes = HttpStatusCodesExtensions.GetTransientHttpStatusCodes().ToList();
+            _resetType = CircuitBreakerPolicyExecutorResetTypes.Quick;
         }
 
+        public CircuitBreakerPolicyExecutor WithReset(CircuitBreakerPolicyExecutorResetTypes resetType)
+        {
+            _resetType = resetType;
+            return this;
+        }
+        
         public Task TriggerFromExceptionAsync<TException>(Exception exception)
             where TException : Exception
         {
@@ -52,8 +66,8 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
                 responseHttpStatusCode: httpStatusCode);
             return TriggerCircuitBreakerFromTransientStatusCodeAsync(handledRequestPath, httpStatusCode);
         }
-
-        public async ValueTask WaitForResetAsync()
+        
+        private async Task WaitResetAsync()
         {
             // wait for the duration of break so that the circuit goes into half open state
             await Task.Delay(TimeSpan.FromSeconds(_circuitBreakerOptions.DurationOfBreakInSecs + 0.05));
@@ -132,9 +146,19 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary
             }
         }
 
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
-            return WaitForResetAsync();
+            switch (_resetType)
+            {
+                case CircuitBreakerPolicyExecutorResetTypes.Quick:
+                    _httpClient.ResetCircuitBreakerPolicy();
+                    break;
+                case CircuitBreakerPolicyExecutorResetTypes.Normal:
+                    await WaitResetAsync();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
         }
     }
 }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyTests.cs
@@ -298,6 +298,51 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
         }
 
         /// <summary>
+        /// This tests that all the <see cref="ICircuitBreakerPolicyEventHandler"/> events are triggered with the correct values.
+        /// Previous tests would only assert the break and reset events from the circuit breaker event handler.
+        /// This is because to check the on half open events takes time and instead of having all the circuit breaker related
+        /// tests be slow, only this one is.
+        /// </summary>
+        [Fact]
+        public async Task AddCircuitBreakerPolicy7()
+        {
+            var circuitBreakerPolicyEventHandlerCalls = new CircuitBreakerPolicyEventHandlerCalls();
+            var testHttpMessageHandler = new TestHttpMessageHandler();
+            const string httpClientName = "GitHub";
+            var circuitBreakerOptions = new CircuitBreakerOptions
+            {
+                DurationOfBreakInSecs = 0.05,
+                SamplingDurationInSecs = 0.1,
+                FailureThreshold = 0.6,
+                MinimumThroughput = 10,
+            };
+            var services = new ServiceCollection();
+            services.AddSingleton(circuitBreakerPolicyEventHandlerCalls);
+            services
+                .AddHttpClient(httpClientName)
+                .ConfigureHttpClient(client => client.BaseAddress = new Uri("https://github.com"))
+                .AddCircuitBreakerPolicy<TestCircuitBreakerPolicyEventHandler>(options =>
+                {
+                    options.DurationOfBreakInSecs = circuitBreakerOptions.DurationOfBreakInSecs;
+                    options.SamplingDurationInSecs = circuitBreakerOptions.SamplingDurationInSecs;
+                    options.FailureThreshold = circuitBreakerOptions.FailureThreshold;
+                    options.MinimumThroughput = circuitBreakerOptions.MinimumThroughput;
+                })
+                .ConfigurePrimaryHttpMessageHandler(() => testHttpMessageHandler);
+
+            var serviceProvider = services.BuildServiceProvider();
+            var httpClient = serviceProvider.InstantiateNamedHttpClient(httpClientName);
+            var circuitBreakerAsserter = httpClient
+                .CircuitBreakerPolicyAsserter(circuitBreakerOptions, testHttpMessageHandler)
+                .WithReset(CircuitBreakerPolicyExecutorResetTypes.Normal);
+            await circuitBreakerAsserter.HttpClientShouldContainCircuitBreakerPolicyAsync();
+            circuitBreakerAsserter.EventHandlerShouldReceiveExpectedEvents(
+                count: 15, // the circuitBreakerAsserter.HttpClientShouldContainCircuitBreakerPolicyAsync triggers the circuit breaker 15 times
+                httpClientName: httpClientName,
+                eventHandlerCalls: circuitBreakerPolicyEventHandlerCalls);
+        }
+
+        /// <summary>
         /// This tests that the policies added to the <see cref="HttpClient"/> by the
         /// CircuitBreakerHttpClientBuilderExtensions.AddCircuitBreakerPolicy methods are unique.
         ///
@@ -328,7 +373,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
                 })
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    circuitBreakerPolicy1 = httpMessageHandlerBuilder.AdditionalHandlers
+                    circuitBreakerPolicy1 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncPolicyWrap<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });
@@ -343,7 +388,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
                 })
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    circuitBreakerPolicy2 = httpMessageHandlerBuilder.AdditionalHandlers
+                    circuitBreakerPolicy2 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncPolicyWrap<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });
@@ -397,7 +442,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
 
             var serviceProvider = services.BuildServiceProvider();
             var httpClient = serviceProvider.InstantiateNamedHttpClient("GitHub");
-            await using var circuitBreaker = httpClient.CircuitBreakerExecutor(circuitBreakerOptions, testHttpMessageHandler);
+            var circuitBreaker = httpClient.CircuitBreakerExecutor(circuitBreakerOptions, testHttpMessageHandler);
             await circuitBreaker.TriggerFromTransientHttpStatusCodeAsync(HttpStatusCode.ServiceUnavailable);
             // after the above the circuit state is now open which means the following http request, if it hit the
             // circuit breaker policy, would throw a BrokenCircuitException/IsolatedCircuitException; however,

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyTests.cs
@@ -302,6 +302,8 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
         /// Previous tests would only assert the break and reset events from the circuit breaker event handler.
         /// This is because to check the on half open events takes time and instead of having all the circuit breaker related
         /// tests be slow, only this one is.
+        ///
+        /// This test is able to check the on half open events because the reset type on the circuit breaker is set to CircuitBreakerPolicyExecutorResetTypes.Normal.
         /// </summary>
         [Fact]
         public async Task AddCircuitBreakerPolicy7()

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Extensions/AddFallbackPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Fallback/Extensions/AddFallbackPolicyTests.cs
@@ -131,7 +131,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Fallback.Extensions
                 .AddFallbackPolicy()
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    fallbackPolicy1 = httpMessageHandlerBuilder.AdditionalHandlers
+                    fallbackPolicy1 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncPolicyWrap<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });
@@ -140,7 +140,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Fallback.Extensions
                 .AddFallbackPolicy()
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    fallbackPolicy2 = httpMessageHandlerBuilder.AdditionalHandlers
+                    fallbackPolicy2 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncPolicyWrap<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePoliciesAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePoliciesAsserter.cs
@@ -5,6 +5,7 @@ using DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary;
 using DotNet.Sdk.Extensions.Tests.Polly.Http.Fallback.Auxiliary;
 using DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Auxiliary;
 using DotNet.Sdk.Extensions.Tests.Polly.Http.Timeout.Auxiliary;
+using Polly.CircuitBreaker;
 
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Resilience.Auxiliary
 {

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePoliciesAsserter.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Resilience/Auxiliary/ResiliencePoliciesAsserter.cs
@@ -5,7 +5,6 @@ using DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Auxiliary;
 using DotNet.Sdk.Extensions.Tests.Polly.Http.Fallback.Auxiliary;
 using DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Auxiliary;
 using DotNet.Sdk.Extensions.Tests.Polly.Http.Timeout.Auxiliary;
-using Polly.CircuitBreaker;
 
 namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Resilience.Auxiliary
 {

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyTests.cs
@@ -293,7 +293,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Extensions
                 })
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    retryPolicy1 = httpMessageHandlerBuilder.AdditionalHandlers
+                    retryPolicy1 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncRetryPolicy<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });
@@ -306,7 +306,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Extensions
                 })
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    retryPolicy2 = httpMessageHandlerBuilder.AdditionalHandlers
+                    retryPolicy2 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncRetryPolicy<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyTests.cs
@@ -263,7 +263,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Timeout.Extensions
                 })
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    timeoutPolicy1 = httpMessageHandlerBuilder.AdditionalHandlers
+                    timeoutPolicy1 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncTimeoutPolicy<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });
@@ -275,7 +275,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Timeout.Extensions
                 })
                 .ConfigureHttpMessageHandlerBuilder(httpMessageHandlerBuilder =>
                 {
-                    timeoutPolicy2 = httpMessageHandlerBuilder.AdditionalHandlers
+                    timeoutPolicy2 = httpMessageHandlerBuilder
                         .GetPolicies<AsyncTimeoutPolicy<HttpResponseMessage>>()
                         .FirstOrDefault();
                 });


### PR DESCRIPTION
Add a way to do a quick reset of the circuit breaker so avoid all the circuit breaker tests from taking a few secs.

This way only 1 test takes a few secs. This test specifically checks some events which cannot be tested when using the quick reset.
