### PR TITLE
dotnet-format-17-Dec-2021: fix code guidelines violations

### DIFF
--- a/tests/DotNet.Sdk.Extensions.Tests/Options/ValidateEagerly/OptionsValidateEagerlyWithValidateDataAnnotationsTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Options/ValidateEagerly/OptionsValidateEagerlyWithValidateDataAnnotationsTests.cs
@@ -34,7 +34,7 @@ namespace DotNet.Sdk.Extensions.Tests.Options.ValidateEagerly
                 })
                 .Build();
             var validationException = await Should.ThrowAsync<OptionsValidationException>(host.StartAsync());
-            //validationException.Message.ShouldBe("DataAnnotation validation failed for members: 'SomeOption' with the error: 'The SomeOption field is required.'.");
+            // validationException.Message.ShouldBe("DataAnnotation validation failed for members: 'SomeOption' with the error: 'The SomeOption field is required.'.");
             validationException.Message.ShouldBe("DataAnnotation validation failed for 'MyOptions2' members: 'SomeOption' with the error: 'The SomeOption field is required.'.");
         }
 

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyOptionsValidationTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/CircuitBreaker/Extensions/AddCircuitBreakerPolicyOptionsValidationTests.cs
@@ -45,7 +45,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
+            // exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
             exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
         }
 
@@ -79,7 +79,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'SamplingDurationInSecs' with the error: 'The field SamplingDurationInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
+            // exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'SamplingDurationInSecs' with the error: 'The field SamplingDurationInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
             exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'SamplingDurationInSecs' with the error: 'The field SamplingDurationInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
         }
 
@@ -115,7 +115,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'FailureThreshold' with the error: 'The field FailureThreshold must be between {double.Epsilon} and {1}.'.");
+            // exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'FailureThreshold' with the error: 'The field FailureThreshold must be between {double.Epsilon} and {1}.'.");
             exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'FailureThreshold' with the error: 'The field FailureThreshold must be between {double.Epsilon} and {1}.'.");
         }
 
@@ -148,7 +148,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'MinimumThroughput' with the error: 'The field MinimumThroughput must be between {2} and {int.MaxValue}.'.");
+            // exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'MinimumThroughput' with the error: 'The field MinimumThroughput must be between {2} and {int.MaxValue}.'.");
             exception.Message.ShouldBe($"DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'MinimumThroughput' with the error: 'The field MinimumThroughput must be between {2} and {int.MaxValue}.'.");
         }
 
@@ -230,7 +230,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.CircuitBreaker.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
+            // exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
             exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for 'CircuitBreakerOptions' members: 'DurationOfBreakInSecs' with the error: 'The field DurationOfBreakInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
         }
     }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyOptionsValidationTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyOptionsValidationTests.cs
@@ -42,7 +42,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
+            // exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
             exception.Message.ShouldBe($"DataAnnotation validation failed for 'RetryOptions' members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
         }
 
@@ -97,7 +97,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'MedianFirstRetryDelayInSecs' with the error: 'The field MedianFirstRetryDelayInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
+            // exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'MedianFirstRetryDelayInSecs' with the error: 'The field MedianFirstRetryDelayInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
             exception.Message.ShouldBe($"DataAnnotation validation failed for 'RetryOptions' members: 'MedianFirstRetryDelayInSecs' with the error: 'The field MedianFirstRetryDelayInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
         }
 
@@ -175,7 +175,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
+            // exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
             exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for 'RetryOptions' members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
         }
     }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyOptionsValidationTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Timeout/Extensions/AddTimeoutPolicyOptionsValidationTests.cs
@@ -41,7 +41,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Timeout.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
+            // exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
             exception.Message.ShouldBe($"DataAnnotation validation failed for 'TimeoutOptions' members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
         }
 
@@ -111,7 +111,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Timeout.Extensions
             {
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
-            //exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
+            // exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
             exception.Message.ShouldBe($"A validation error has occurred.; DataAnnotation validation failed for 'TimeoutOptions' members: 'TimeoutInSecs' with the error: 'The field TimeoutInSecs must be between {double.Epsilon} and {double.MaxValue}.'.");
         }
     }


### PR DESCRIPTION
**dotnet format** [workflow run](https://github.com/edumserrano/dot-net-sdk-extensions/actions/runs/1592222580) detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

## Note
Sometimes the fix provided by the analyzers produces unecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the `Unmerged change from project ...` comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:
```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```