### PR TITLE
dotnet-format-17-Dec-2021: fix code guidelines violations

### DIFF
--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationWebHostTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationWebHostTests.cs
@@ -18,9 +18,9 @@ namespace DotNet.Sdk.Extensions.Testing.Tests.Configuration
     public class AddTestConfigurationWebHostTests
     {
         /// <summary>
-        /// Tests that <see cref="Microsoft.AspNetCore.WebHost.CreateDefaultBuilder()"/> adds two <see cref="JsonConfigurationProvider"/>
+        /// Tests that <see cref="WebHost.CreateDefaultBuilder()"/> adds two <see cref="JsonConfigurationProvider"/>
         /// to the app configuration.
-        /// This test serves as a control test because all the tests use the <see cref="Microsoft.AspNetCore.WebHost.CreateDefaultBuilder()"/> as a way
+        /// This test serves as a control test because all the tests use the <see cref="WebHost.CreateDefaultBuilder()"/> as a way
         /// to setup a <see cref="IWebHost"/> with several <see cref="ConfigurationProvider"/> and at least two <see cref="JsonConfigurationProvider"/>.
         /// If this changes in the future then I could start having false positives on the other tests.
         /// </summary>

--- a/tests/DotNet.Sdk.Extensions.Tests/Options/AddOptionsValueTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Options/AddOptionsValueTests.cs
@@ -37,7 +37,7 @@ namespace DotNet.Sdk.Extensions.Tests.Options
             var configuration = new ConfigurationRoot(new List<IConfigurationProvider>());
             var servicesArgumentNullException = Should.Throw<ArgumentNullException>(() =>
             {
-                Extensions.Options.OptionsBuilderExtensions.AddOptionsValue<MyOptions>(services: null!, configuration);
+                OptionsBuilderExtensions.AddOptionsValue<MyOptions>(services: null!, configuration);
             });
             servicesArgumentNullException.Message.ShouldBe("Value cannot be null. (Parameter 'services')");
         }
@@ -78,7 +78,7 @@ namespace DotNet.Sdk.Extensions.Tests.Options
             var serviceCollection = new ServiceCollection();
             var servicesArgumentNullException = Should.Throw<ArgumentNullException>(() =>
             {
-                Extensions.Options.OptionsBuilderExtensions.AddOptionsValue<MyOptions>(services: null!, configuration, sectionName: "MyOptionsSection");
+                OptionsBuilderExtensions.AddOptionsValue<MyOptions>(services: null!, configuration, sectionName: "MyOptionsSection");
             });
             servicesArgumentNullException.Message.ShouldBe("Value cannot be null. (Parameter 'services')");
             var configurationArgumentNullException = Should.Throw<ArgumentNullException>(() =>
@@ -115,7 +115,7 @@ namespace DotNet.Sdk.Extensions.Tests.Options
         {
             var optionsBuilderArgumentNullException = Should.Throw<ArgumentNullException>(() =>
             {
-                Extensions.Options.OptionsBuilderExtensions.AddOptionsValue<MyOptions>(optionsBuilder: null!);
+                OptionsBuilderExtensions.AddOptionsValue<MyOptions>(optionsBuilder: null!);
             });
             optionsBuilderArgumentNullException.Message.ShouldBe("Value cannot be null. (Parameter 'optionsBuilder')");
         }

--- a/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyOptionsValidationTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Tests/Polly/Http/Retry/Extensions/AddRetryPolicyOptionsValidationTests.cs
@@ -43,7 +43,7 @@ namespace DotNet.Sdk.Extensions.Tests.Polly.Http.Retry.Extensions
                 serviceProvider.InstantiateNamedHttpClient(httpClientName);
             });
 #if NET6_0
-            exception.Message.ShouldBe($"DataAnnotation validation failed for 'RetryOptions' members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");           
+            exception.Message.ShouldBe($"DataAnnotation validation failed for 'RetryOptions' members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
 #else
             exception.Message.ShouldBe($"DataAnnotation validation failed for members: 'RetryCount' with the error: 'The field RetryCount must be between {0} and {int.MaxValue}.'.");
 #endif


### PR DESCRIPTION
**dotnet format** [workflow run](https://github.com/edumserrano/dot-net-sdk-extensions/actions/runs/1593383982) detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

## Note
Sometimes the fix provided by the analyzers produces unecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the `Unmerged change from project ...` comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:
```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```