### PR TITLE
dotnet-format-01-Jan-2022: fix code guidelines violations

### DIFF
--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/TestHttpMessageHandlerTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/HttpMocking/HttpMessageHandlers/TestHttpMessageHandlerTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using DotNet.Sdk.Extensions.Testing.HttpMocking.HttpMessageHandlers;
 using DotNet.Sdk.Extensions.Testing.HttpMocking.HttpMessageHandlers.ResponseMocking;


### PR DESCRIPTION
# [dotnet format](https://github.com/edumserrano/dot-net-sdk-extensions/actions/runs/1642225095)

**dotnet format** detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

## Note

Sometimes the fix provided by the analyzers produces unecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the Unmerged change from project ... comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:

`csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
`
