### PR TITLE
dotnet-format-12-Jan-2022: fix code guidelines violations

### DIFF
--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationHostTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationHostTests.cs
@@ -31,11 +31,23 @@ namespace DotNet.Sdk.Extensions.Testing.Tests.Configuration
                 .CreateDefaultBuilder()
                 .Build();
 
-
-                var a = 2;
-
-
             var configuration = (ConfigurationRoot)host.Services.GetRequiredService<IConfiguration>();
+
+/* Unmerged change from project 'DotNet.Sdk.Extensions.Testing.Tests(net5.0)'
+Before:
+            var configuration = (ConfigurationRoot)host.Services.GetRequiredService<IConfiguration>();
+            var jsonConfigurationProviders = configuration.Providers.OfType<JsonConfigurationProvider>();
+After:
+            var jsonConfigurationProviders = configuration.Providers.OfType<JsonConfigurationProvider>();
+*/
+
+/* Unmerged change from project 'DotNet.Sdk.Extensions.Testing.Tests(net6.0)'
+Before:
+            var configuration = (ConfigurationRoot)host.Services.GetRequiredService<IConfiguration>();
+            var jsonConfigurationProviders = configuration.Providers.OfType<JsonConfigurationProvider>();
+After:
+            var jsonConfigurationProviders = configuration.Providers.OfType<JsonConfigurationProvider>();
+*/
             var jsonConfigurationProviders = configuration.Providers.OfType<JsonConfigurationProvider>();
             jsonConfigurationProviders.Count().ShouldBe(2);
         }


### PR DESCRIPTION
# [dotnet format](https://github.com/edumserrano/dot-net-sdk-extensions/actions/runs/1685565315)

**dotnet format** detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

## Note

Sometimes the fix provided by the analyzers produces unnecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the Unmerged change from project ... comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:

```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```
