### PR TITLE
dotnet-format-19-Jan-2022: fix code guidelines violations

### DIFF
--- a/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationHostTests.cs
+++ b/tests/DotNet.Sdk.Extensions.Testing.Tests/Configuration/AddTestConfigurationHostTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 namespace DotNet.Sdk.Extensions.Testing.Tests.Configuration
 {
     [Trait("Category", XUnitCategories.Configuration)]
-       public class AddTestConfigurationHostTests
+    public class AddTestConfigurationHostTests
     {
         /// <summary>
         /// Tests that <see cref="Host.CreateDefaultBuilder()"/> adds two <see cref="JsonConfigurationProvider"/>


### PR DESCRIPTION
# [dotnet format](https://github.com/edumserrano/dot-net-sdk-extensions/actions/runs/1719038085) for commit c7d5ddc1165eff20d0425805157617b248c7c8ff

**dotnet format** detected code guidelines violations and automatically created this PR.

:warning: Please review the suggested changes before merging.

<details>
<summary><strong>Note</strong></summary>
</br>

Sometimes the fix provided by the analyzers produces unnecessary comments when formatting files.

This should only happen if the project supports multiple target frameworks and the fix doesn't produce the same output for all. However, it seems that sometimes the Unmerged change from project ... comment shows up even though the fix produced the same output.

If this happens, just delete the comments added. Otherwise, consider incorporating the commented out code using [preprocessor directives to control conditional compilation](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives#conditional-compilation).
Example:

```csharp
#if NET5_0
    ...
#elif NETCOREAPP3_1
    ...
#endif
```

</details>
