### PR TITLE
Release NuGet DotNet.Sdk.Extensions 2.0.0

### DIFF
--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>DotNet-Sdk-Extensions</PackageId>
-    <Version>1.0.13-alpha</Version>
+    <Version>2.0.0</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -28,17 +28,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\docs\nuget\$(PackageReadmeFileName)" Pack="true" PackagePath="\" />
+    <None Include="..\..\docs\nuget\$(PackageReadmeFileName)" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Create 2.0.0 release for DotNet.Sdk.Extensions NuGet.
Current version of DotNet.Sdk.Extensions NuGet is: [TODO-CURRENT-VERSION](TODO-URL).

Release notes can be found at #326.

<details>
<summary><strong>Created from:</strong></summary>
</br>

Issue: #326
Workflow: [Slash command dispatch](https://github.com/edumserrano/dot-net-sdk-extensions/actions/workflows/dispatch-commands.yml)
Commmit: <no value>

</details>
