### PR TITLE
Release NuGet DotNet.Sdk.Extensions 1.0.14-alpha

### DIFF
--- a/D:\Dev\edumserrano\dot-net-sdk-extensions\src\DotNet.Sdk.Extensions\DotNet.Sdk.Extensions.csproj
+++ b/D:\Dev\edumserrano\dot-net-sdk-extensions\src\DotNet.Sdk.Extensions\DotNet.Sdk.Extensions.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <PackageReadmeFileName>dotnet-sdk-extensions-nuget-readme.md</PackageReadmeFileName>
+
+    <!--nuget package info-->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageId>DotNet-Sdk-Extensions</PackageId>
+    <Version>1.0.14-alpha</Version>
+    <Owners>Eduardo Serrano</Owners>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/edumserrano/dot-net-sdk-extensions</PackageProjectUrl>
+    <Description>Extensions for the .NET SDK. For more information see https://github.com/edumserrano/dot-net-sdk-extensions. </Description>
+    <PackageReadmeFile>$(PackageReadmeFileName)</PackageReadmeFile> 
+    <PackageTags>dotnet core extensions csharp c#</PackageTags>
+
+    <!--<RepositoryUrl>https://github.com/edumserrano/dot-net-sdk-extensions</RepositoryUrl>-->
+    <!--<PackageIconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</PackageIconUrl>-->
+    <!--<PackageReleaseNotes>Summary of changes made in this release of the package.</PackageReleaseNotes>-->
+    <!--<Copyright>Copyright</Copyright>-->
+    <!--nuget package info-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\docs\nuget\$(PackageReadmeFileName)" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Create 1.0.14-alpha release for DotNet.Sdk.Extensions NuGet.
Current version of DotNet.Sdk.Extensions NuGet is: [TODO-CURRENT-VERSION](TODO-URL).

Release notes can be found at #326.

<details>
<summary><strong>Created from:</strong></summary>
</br>

Issue: #326
Workflow: [Slash command dispatch](https://github.com/edumserrano/dot-net-sdk-extensions/actions/workflows/dispatch-commands.yml)
Commmit: 0cc24431fca8f5744335f4fb112447d45a550fa4

</details>
