### PR TITLE
Release NuGet DotNet.Sdk.Extensions 1.0.14-alpha

### DIFF
--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>DotNet-Sdk-Extensions</PackageId>
-    <Version>1.0.13-alpha</Version>
+    <Version>1.0.14-alpha</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Create 1.0.14-alpha release for DotNet.Sdk.Extensions NuGet.
Current version of DotNet.Sdk.Extensions NuGet is: [TODO-CURRENT-VERSION](TODO-URL).

Release notes can be found at #326.

<details>
<summary><strong>Created from:</strong></summary>
</br>

Issue: #326
Workflow: [Slash command dispatch](https://github.com/edumserrano/dot-net-sdk-extensions/actions/workflows/dispatch-commands.yml)
Commmit: 905e7dff46745dc1b70e8e944b689a18dbd6e9aa

</details>
