### PR TITLE
Release NuGet DotNet-Sdk-Extensions-Testing 1.0.13-alpha

### DIFF
--- a/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
+++ b/src/DotNet.Sdk.Extensions.Testing/DotNet.Sdk.Extensions.Testing.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>DotNet-Sdk-Extensions-Testing</PackageId>
-    <Version>1.0.14-alpha</Version>
+    <Version>1.0.13-alpha</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **1.0.13-alpha** version of the **DotNet-Sdk-Extensions-Testing** NuGet.
Current version of DotNet-Sdk-Extensions-Testing NuGet is: [1.0.13-alpha](https://www.nuget.org/packages/DotNet-Sdk-Extensions-Testing).

Release notes can be found at #326.
