### PR TITLE
Release NuGet DotNet-Sdk-Extensions 1.0.14-alpha

### DIFF
--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>DotNet-Sdk-Extensions</PackageId>
-    <Version>1.0.13-alpha</Version>
+    <Version>1.0.14-alpha</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **1.0.14-alpha** version of the **DotNet-Sdk-Extensions** NuGet.
Current version of DotNet-Sdk-Extensions NuGet is: [1.0.13-alpha](https://www.nuget.org/packages/DotNet-Sdk-Extensions).

Release notes can be found at #326.
