### PR TITLE
Release NuGet dotnet-sdk-extensions 1.0.13-alpha

### DIFF
--- a/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
+++ b/src/DotNet.Sdk.Extensions/DotNet.Sdk.Extensions.csproj
@@ -11,7 +11,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageId>DotNet-Sdk-Extensions</PackageId>
-    <Version>1.0.14-alpha</Version>
+    <Version>1.0.13-alpha</Version>
     <Owners>Eduardo Serrano</Owners>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Release **1.0.13-alpha** version of the **dotnet-sdk-extensions** NuGet.
Current version of dotnet-sdk-extensions NuGet is: [1.0.14-alpha](https://www.nuget.org/packages/dotnet-sdk-extensions).

Release notes can be found at #462.
